### PR TITLE
Method specific route handler builders

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
+}

--- a/lib/route.ts
+++ b/lib/route.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from "./types.ts";
+import type { Handler, Middleware } from "./types.ts";
 
 import {
   match,
@@ -7,24 +7,65 @@ import {
 
 import { createContext, type Operation } from "./deps/effection.ts";
 
-const ParamsContext = createContext<MatchResult["params"]>(
-  "revolution.params",
-);
+const ParamsContext = createContext<MatchResult["params"]>("revolution.params");
 
 export function* useParams<T extends object>(): Operation<T> {
   return (yield* ParamsContext) as T;
 }
 
+function buildMethodRoute<T>(
+  method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH",
+  handler: Handler<Request, T>,
+): Middleware<Request, T> {
+  return function* (request, next) {
+    if (request.method === method) {
+      return yield* handler(request);
+    } else {
+      return yield* next(request);
+    }
+  };
+}
+
+export function GET<T>(handler: Handler<Request, T>): Middleware<Request, T> {
+  return buildMethodRoute("GET", handler);
+}
+
+export function POST<T>(handler: Handler<Request, T>): Middleware<Request, T> {
+  return buildMethodRoute("POST", handler);
+}
+
+export function PUT<T>(handler: Handler<Request, T>): Middleware<Request, T> {
+  return buildMethodRoute("PUT", handler);
+}
+
+export function PATCH<T>(handler: Handler<Request, T>): Middleware<Request, T> {
+  return buildMethodRoute("PATCH", handler);
+}
+
+export function DELETE<T>(
+  handler: Handler<Request, T>,
+): Middleware<Request, T> {
+  return buildMethodRoute("DELETE", handler);
+}
+
 export function route<T>(
   path: string,
-  handler: Middleware<Request, T>,
+  ...middlewares: Middleware<Request, T>[]
 ): Middleware<Request, T> {
+  const inlinedMiddleware = middlewares.slice(1).reduce(
+    (inlined, current) => {
+      return function* (request, next) {
+        return yield* inlined(request, (request) => current(request, next));
+      };
+    },
+    middlewares[0],
+  );
   return function* (request, next) {
     let pathname = new URL(request.url).pathname;
     let result = match(path)(pathname);
     if (result) {
       yield* ParamsContext.set(result.params);
-      return yield* handler(request, next);
+      return yield* inlinedMiddleware(request, next);
     } else {
       return yield* next(request);
     }

--- a/lib/route.ts
+++ b/lib/route.ts
@@ -6,6 +6,7 @@ import {
 } from "https://deno.land/x/path_to_regexp@v6.2.1/index.ts";
 
 import { createContext, type Operation } from "./deps/effection.ts";
+import { concat } from "./middleware.ts";
 
 const ParamsContext = createContext<MatchResult["params"]>("revolution.params");
 
@@ -52,14 +53,7 @@ export function route<T>(
   path: string,
   ...middlewares: Middleware<Request, T>[]
 ): Middleware<Request, T> {
-  const inlinedMiddleware = middlewares.slice(1).reduce(
-    (inlined, current) => {
-      return function* (request, next) {
-        return yield* inlined(request, (request) => current(request, next));
-      };
-    },
-    middlewares[0],
-  );
+  const inlinedMiddleware = concat(...middlewares);
   return function* (request, next) {
     let pathname = new URL(request.url).pathname;
     let result = match(path)(pathname);

--- a/lib/route.ts
+++ b/lib/route.ts
@@ -1,4 +1,4 @@
-import type { Handler, Middleware } from "./types.ts";
+import type { Middleware } from "./types.ts";
 
 import {
   match,
@@ -16,35 +16,43 @@ export function* useParams<T extends object>(): Operation<T> {
 
 function buildMethodRoute<T>(
   method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH",
-  handler: Handler<Request, T>,
+  handler: Middleware<Request, T>,
 ): Middleware<Request, T> {
   return function* (request, next) {
     if (request.method === method) {
-      return yield* handler(request);
+      return yield* handler(request, next);
     } else {
       return yield* next(request);
     }
   };
 }
 
-export function GET<T>(handler: Handler<Request, T>): Middleware<Request, T> {
+export function GET<T>(
+  handler: Middleware<Request, T>,
+): Middleware<Request, T> {
   return buildMethodRoute("GET", handler);
 }
 
-export function POST<T>(handler: Handler<Request, T>): Middleware<Request, T> {
+export function POST<T>(
+  handler: Middleware<Request, T>,
+): Middleware<Request, T> {
   return buildMethodRoute("POST", handler);
 }
 
-export function PUT<T>(handler: Handler<Request, T>): Middleware<Request, T> {
+export function PUT<T>(
+  handler: Middleware<Request, T>,
+): Middleware<Request, T> {
   return buildMethodRoute("PUT", handler);
 }
 
-export function PATCH<T>(handler: Handler<Request, T>): Middleware<Request, T> {
+export function PATCH<T>(
+  handler: Middleware<Request, T>,
+): Middleware<Request, T> {
   return buildMethodRoute("PATCH", handler);
 }
 
 export function DELETE<T>(
-  handler: Handler<Request, T>,
+  handler: Middleware<Request, T>,
 ): Middleware<Request, T> {
   return buildMethodRoute("DELETE", handler);
 }

--- a/lib/sse.ts
+++ b/lib/sse.ts
@@ -15,9 +15,12 @@ export function sse<
   T extends ServerSentEventMessage,
   TDone extends ServerSentEventMessage,
 >(
-  op: (send: (value: T) => Operation<void>) => Operation<TDone>,
+  op: (
+    request: Request,
+    send: (value: T) => Operation<void>,
+  ) => Operation<TDone>,
 ): Middleware<Request, Response> {
-  return function* () {
+  return function* (request: Request, _next) {
     let body = new ServerSentEventStream();
 
     let response = new Response(body.readable, {
@@ -44,7 +47,7 @@ export function sse<
         }
       });
 
-      let result = yield* op(events.send);
+      let result = yield* op(request, events.send);
       yield* events.close(result);
     });
   };

--- a/test/route.test.ts
+++ b/test/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "./suite.ts";
-import { respondNotFound, route, useParams } from "../mod.ts";
+import { GET, respondNotFound, route, useParams } from "../mod.ts";
+import { Operation } from "../lib/deps/effection.ts";
 
 describe("route", () => {
   it("makes the params available", function* () {
@@ -13,5 +14,30 @@ describe("route", () => {
     });
 
     expect(yield* response.text()).toEqual("id=cowboyd");
+  });
+
+  describe("method-specific routes", () => {
+    it("skips a handler with different method", function* () {
+      let getRoute = route(
+        "/users/:id",
+        GET(function* () {
+          throw new Error("SHOULD NEVER HIT");
+          // deno-lint-ignore no-unreachable
+          return new Response();
+        }),
+      );
+
+      let postRoute = function* (): Operation<Response> {
+        let { id } = yield* useParams<{ id: string }>();
+        return new Response(`id=${id}`);
+      };
+
+      let request = new Request("http://localhost:8080/users/cowboyd", {
+        method: "POST",
+      });
+      let response = yield* getRoute(request, postRoute);
+
+      expect(yield* response.text()).toEqual("id=cowboyd");
+    });
   });
 });

--- a/test/streaming.test.ts
+++ b/test/streaming.test.ts
@@ -8,7 +8,7 @@ describe("streaming responses", () => {
   it("can consume an SSE stream", function* () {
     let revolution = createRevolution({
       app: [
-        sse(function* (send) {
+        sse(function* (request, send) {
           for (let i = 3; i > 0; i--) {
             yield* send({ event: "count", data: JSON.stringify(i) });
             yield* sleep(5);


### PR DESCRIPTION
## Motivation

see #4 

in order to enable "Rest'y" api design, we need to be able to support same path, different http method.
This change adds that capability.

## Approach

If you'd like to specify an HTTP method to match for a given route, you can now, optionally, specify a handler-middleware when you build the route. That looks like the following:

```typescript
        route(
          "/healthz",
          GET(function* () {
            return new Response("NOPE");
          }),
        ),
```

I'm currently using `UPPERCASE` http method middleware functions for a couple of reasons.
1. `delete` is a reserved keyword, so we can't use `delete()` for a function name.
2. these function names exactly match the method name strings.

### Alternate Designs

this design was also considered, but using middleware is a bit more composable and testable. 

```typescript
        route("GET", "/healthz",
          function* () {
            return new Response("NOPE");
          },
        ),
```




