### PR TITLE
Preserve context when Response has a driver

### DIFF
--- a/lib/sse.ts
+++ b/lib/sse.ts
@@ -27,7 +27,7 @@ export function sse<
       },
     });
 
-    return drive(response, function* () {
+    return yield* drive(response, function* () {
       let events = createChannel<T, TDone>();
       yield* spawn(function* () {
         let writer = body.writable.getWriter();


### PR DESCRIPTION
## Motivation

Any context that has been built up when a driver is created needs to be preserved. Otherwise, things like the parameters will be lost when the stream driver begins.

## Approach

Capture the context at the point where it is required, and then assign it back onto the context when the stream driver begins
