### PR TITLE
✨ Add <!doctype html> to html serialization

### DIFF
--- a/lib/middleware/serialize-html.ts
+++ b/lib/middleware/serialize-html.ts
@@ -3,7 +3,9 @@ import type { HASTHtmlNode } from "../types.ts";
 import { toHtml } from "npm:hast-util-to-html@9.0.0";
 
 export function serializeHtml(node: HASTHtmlNode): Response {
-  return new Response(toHtml(node), {
+  let doctype = { type: "doctype" } as const;
+
+  return new Response(toHtml([doctype, node]), {
     headers: {
       "Content-Type": "text/html; charset=utf-8;",
     },

--- a/test/revolution.test.tsx
+++ b/test/revolution.test.tsx
@@ -152,7 +152,7 @@ describe("revolution", () => {
 
     expect(response.status).toEqual(200);
     expect(yield* response.text()).toEqual(
-      "<html><body>Hello World</body></html>",
+      "<!doctype html><html><body>Hello World</body></html>",
     );
   });
 
@@ -204,7 +204,7 @@ describe("revolution", () => {
     let response = yield* fetch(`http://${hostname}:${port}`, { signal });
 
     expect(yield* response.text()).toEqual(
-      "<html><body><div>Banner</div>Hello World</body></html>",
+      "<!doctype html><html><body><div>Banner</div>Hello World</body></html>",
     );
   });
 });


### PR DESCRIPTION
## Motivation

Without a proper doctype, html will load in quirks mode.

## Approach

This adds a doctype declaration to force the output to be HTML5 for every single HTML response.

Theoretically, this sets up a situation where you want to serve a doc in quirks mode, but can't.

1) this will never happen
2) when it does, we can figure out how to deal with it at that point.
