### PR TITLE
✨ Make application options available to middleware.

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -26,7 +26,10 @@
         "integrity": "9401a6aa5a3292d639b71beceb19fb53c2148238c4d36b3ddf8c30980baa10e0"
       },
       "@std/cli@0.219.1": {
-        "integrity": "715a9926b58b89ef8a3c91e91633ac5f8176e0f02f6b3a16f0a67309e41a2911"
+        "integrity": "715a9926b58b89ef8a3c91e91633ac5f8176e0f02f6b3a16f0a67309e41a2911",
+        "dependencies": [
+          "jsr:@std/assert@^0.219.1"
+        ]
       },
       "@std/encoding@0.219.1": {
         "integrity": "77b30e481a596cfb2a8f2f38c3165e6035a4f76a7259bf89b6a622ceaf57d575"
@@ -51,10 +54,16 @@
         "integrity": "557c8d4fd82aa6df51bca18d14e08e8df7134816c8defb61c90ac48bf71ad7c4"
       },
       "@std/path@0.219.1": {
-        "integrity": "e5c0ffef3a8ef2b48e9e3d88a1489320e8fb2cc7be767b17c91a1424ffb4c8ed"
+        "integrity": "e5c0ffef3a8ef2b48e9e3d88a1489320e8fb2cc7be767b17c91a1424ffb4c8ed",
+        "dependencies": [
+          "jsr:@std/assert@^0.219.1"
+        ]
       },
       "@std/streams@0.219.1": {
-        "integrity": "6f5dac5773a4fafdbe7ee612d0a0d5a2cbe465b9c9e2c85d371877dc8a52d1d3"
+        "integrity": "6f5dac5773a4fafdbe7ee612d0a0d5a2cbe465b9c9e2c85d371877dc8a52d1d3",
+        "dependencies": [
+          "jsr:@std/assert@^0.219.1"
+        ]
       }
     },
     "npm": {

--- a/lib/sse.ts
+++ b/lib/sse.ts
@@ -42,7 +42,7 @@ export function sse<
       let messages = createChannel<T, never>();
 
       yield* spawn(function* () {
-        for (const message of yield* each(messages)) {
+        for (let message of yield* each(messages)) {
           yield* write(message);
           yield* each.next();
         }


### PR DESCRIPTION
## Motivation

We need to be able to reflect on the application structure in order see options that are available to it. This is what we need to do things like make a sitemap plugin that can reason about all routes together.

## Approach
This stores the options, and then makes them available to anybody interested in the on the middleware stack.