### PR TITLE
✨ respond with redirects

### DIFF
--- a/lib/middleware/http-responses.ts
+++ b/lib/middleware/http-responses.ts
@@ -22,6 +22,21 @@ export function* respondNotFound(): Operation<never> {
   throw new Error("This code is unreachable, but TypeScript don't know.");
 }
 
+export interface RedirectOptions {
+  permanent?: boolean;
+}
+
+export function* respondRedirect(
+  url: string | URL,
+  options: RedirectOptions = {},
+): Operation<never> {
+  let status = options.permanent ? 308 : 307;
+  let respond = yield* ResponseContext;
+  respond(Response.redirect(url, status));
+  yield* suspend();
+  throw new Error("This code is unreachable, but TypeScript don't know.");
+}
+
 export function httpResponsesMiddleware(): HTTPMiddleware {
   return function* httpResponses(request, next): Operation<Response> {
     try {

--- a/test/middleware/http-responses.test.ts
+++ b/test/middleware/http-responses.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "../suite.ts";
-import { concat, httpResponsesMiddleware, respondNotFound } from "../../mod.ts";
+import {
+  concat,
+  httpResponsesMiddleware,
+  respondNotFound,
+  respondRedirect,
+} from "../../mod.ts";
 
 describe("http responses middleware", () => {
   it("can short circuit a middleware stack with a 404", function* () {
@@ -17,5 +22,47 @@ describe("http responses middleware", () => {
     });
 
     expect(response.status).toEqual(404);
+  });
+
+  it("can short circuit a middleware stack with a temporary redirect", function* () {
+    let handler = concat(
+      httpResponsesMiddleware(),
+      function* () {
+        return yield* respondRedirect("https://localhost/other.html");
+      },
+    );
+
+    let request = new Request("http://localhost/test.html");
+
+    let response = yield* handler(request, function* () {
+      throw new Error(`should not reach here.`);
+    });
+
+    expect(response.status).toEqual(307);
+    expect(response.headers.get("location")).toEqual(
+      "https://localhost/other.html",
+    );
+  });
+
+  it("can short circuit a middleware stack with a permanent redirect", function* () {
+    let handler = concat(
+      httpResponsesMiddleware(),
+      function* () {
+        return yield* respondRedirect("https://localhost/other.html", {
+          permanent: true,
+        });
+      },
+    );
+
+    let request = new Request("http://localhost/test.html");
+
+    let response = yield* handler(request, function* () {
+      throw new Error(`should not reach here.`);
+    });
+
+    expect(response.status).toEqual(308);
+    expect(response.headers.get("location")).toEqual(
+      "https://localhost/other.html",
+    );
   });
 });


### PR DESCRIPTION
## Motivation

One of the nice things about using continuations is that you can drop the current frame of execution and just resume where you were before. This lets you do that with HTTP responses. So, for example, if you need to redirect, then it will drop what you're doing and perform the redirect, doing any necessary unwinding as you go along.

## Approach

This adds a `respondRidirect()` operation that let's you quit the current response and proceed directly to redirection