### PR TITLE
Bump to hastx@0.0.11

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -17,7 +17,7 @@
   },
   "lint": {
     "rules": {
-      "exclude": ["prefer-const", "require-yield"]
+      "exclude": ["prefer-const", "require-yield", "no-slow-types"]
     }
   },
   "compilerOptions": {

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,5 @@
 {
   "name": "@frontside/revolution",
-  "exports": "./mod.ts",
   "license": "ISC",
   "publish": {
     "exclude": [
@@ -11,6 +10,10 @@
     "test": "deno test --allow-read --allow-write --allow-env --allow-run --allow-net",
     "build:npm": "deno run -A tasks/build-npm.ts",
     "build:jsr": "deno run -A tasks/build-jsr.ts"
+  },
+  "exports": {
+    ".": "./mod.ts",
+    "./jsx-runtime": "./jsx-runtime.ts"
   },
   "lint": {
     "rules": {
@@ -30,6 +33,7 @@
     "@std/path": "jsr:@std/path@1.0.8",
     "@std/http": "jsr:@std/http@1.0.12",
     "hast": "npm:@types/hast@^3.0.0",
+    "hastx": "npm:hastx@0.0.11",
     "@std/testing": "jsr:@std/testing@1.0.8",
     "revolution/jsx-runtime": "./jsx-runtime.ts",
     "path-to-regexp": "npm:path-to-regexp@8.2.0"

--- a/deno.lock
+++ b/deno.lock
@@ -55,6 +55,8 @@
     "npm:hast-util-select@6.0.1": "6.0.1",
     "npm:hast-util-to-html@9.0.0": "9.0.0",
     "npm:hast-util-to-text@4.0.0": "4.0.0",
+    "npm:hastx@0.0.10": "0.0.10",
+    "npm:hastx@0.0.11": "0.0.11",
     "npm:path-to-regexp@8.2.0": "8.2.0",
     "npm:ts-expect@*": "1.3.0"
   },
@@ -568,6 +570,18 @@
         "hast-util-parse-selector",
         "property-information",
         "space-separated-tokens"
+      ]
+    },
+    "hastx@0.0.10": {
+      "integrity": "sha512-IXizJeqwc+fk2hiJ8hzg5l82qOijtS8OOI9/Vu4LuCQJDAEK0KElNQZysMRz7hD206v5VCFG6lujx9/haW738A==",
+      "dependencies": [
+        "@types/hast@3.0.2"
+      ]
+    },
+    "hastx@0.0.11": {
+      "integrity": "sha512-Q333Ifi2Tr9OGB8K/bprsyc5EgXwpkJAIQKGk7dBSCH8tpRraZ5RAdcZLPlJt97TwbZh3WmmiIAf6vfY/nipeg==",
+      "dependencies": [
+        "@types/hast@3.0.2"
       ]
     },
     "html-void-elements@3.0.0": {
@@ -1202,6 +1216,7 @@
       "jsr:@std/testing@1.0.8",
       "npm:@types/hast@3",
       "npm:esbuild@0.24.2",
+      "npm:hastx@0.0.11",
       "npm:path-to-regexp@8.2.0"
     ]
   }

--- a/jsx-runtime.ts
+++ b/jsx-runtime.ts
@@ -1,6 +1,7 @@
-import type * as html from "https://deno.land/x/hastx@v0.0.10/html.ts";
+import type * as html from "hastx/html";
 import type * as hast from "hast";
 import type { JSXChild, JSXElement } from "./lib/types.ts";
+
 export type * from "./lib/types.ts";
 
 export type JSXElementProps = Record<string, string> & {


### PR DESCRIPTION
## Motivation

I want to be able to publish a new version of Revolution with an upgraded path-to-regexp to 8.2.0, which allows optional arguments. 

## Approach

Using freshly released hastx@0.0.11