### PR TITLE
Added missing entrypoint for jsx-runtime

### DIFF
--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -10,7 +10,13 @@ if (!version) {
 }
 
 await build({
-  entryPoints: ["./mod.ts"],
+  entryPoints: [
+    "./mod.ts",
+    {
+      name: "./jsx-runtime",
+      path: "jsx-runtime.ts"
+    }
+  ],
   outDir,
   shims: {
     deno: false,

--- a/tasks/build-npm.ts
+++ b/tasks/build-npm.ts
@@ -14,8 +14,8 @@ await build({
     "./mod.ts",
     {
       name: "./jsx-runtime",
-      path: "jsx-runtime.ts"
-    }
+      path: "jsx-runtime.ts",
+    },
   ],
   outDir,
   shims: {


### PR DESCRIPTION
## Motivation

0.7.0 is missing the `jsx-runtime` entrypoint

## Approach

Add it to the build-npm task
