### PR TITLE
refactor: avoid nested scope.run in request handler

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,6 @@
 {
   "name": "@frontside/revolution",
+  "version": "0.8.1",
   "license": "ISC",
   "publish": {
     "exclude": [


### PR DESCRIPTION
## Summary
- refactor useServer request handling to avoid nesting scope.run inside another scope.run
- keep response production and stream driver execution as separate top-level runs in the same scope
- preserve existing driver behavior (params context restore, abort race, and resource closed handling)

## Verification
- deno lint
- deno task test